### PR TITLE
Update B&R score, add Yes to Open Docs for Beckhoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ sort: score, alphabetical
 | Siemens S7            |                |                   |           |                       |         |                           |               |                    | 0     |
 | Siemens PCS7          |                |                   |           |                       |         |                           |               |                    | 0     |
 | Siemens PCS7 NEO      |                |                   |           |                       |         |                           |               |                    | 0     |
-| B&R Automation Studio |                |                   |           |                       |         |                           |               |                    | 0     |
+| B&R Automation Studio | YES           |  YES           |           |                       |         |                           |  YES       |                    | 3     |
 | B&R Aprol             |                |                   |           |                       |         |                           |               |                    | 0     |
 | ...                   |                |                   |           |                       |         |                           |               |                    | 0     |
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ sort: score, alphabetical
 | Siemens S7            |                |                   |           |                       |         |                           |               |                    | 0     |
 | Siemens PCS7          |                |                   |           |                       |         |                           |               |                    | 0     |
 | Siemens PCS7 NEO      |                |                   |           |                       |         |                           |               |                    | 0     |
-| B&R Automation Studio | YES           |  YES           |           |                       |         |                           |  YES       |                    | 3     |
+| B&R Automation Studio | YES           |  YES           |           |  YES               |         |                           |  YES       |                    | 4     |
 | B&R Aprol             |                |                   |           |                       |         |                           |               |                    | 0     |
 | ...                   |                |                   |           |                       |         |                           |               |                    | 0     |
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ sort: score, alphabetical
 
 | system                | plain text [1] | open download [2] | Linux [3] | testing framework [4] | cli [5] | transparent licensing [6] | open docs [7] | HW independent [8] | score |
 | --------------------- | -------------- | ----------------- | --------- | --------------------- | ------- | ------------------------- | ------------- | ------------------ | ----- |
+| B&R Automation Studio | YES            | YES               |           | YES                   |         |                           | YES           |                    | 4     |
 | Siemens AX            | YES            |                   |           | YES                   | YES     |                           |               |                    | 3     |
-| Beckhoff TwinCAT 3    |                | YES               |           | YES                   |         |                           |               |                    | 2     |
+| Beckhoff TwinCAT 3    |                | YES               |           | YES                   |         |                           | YES           |                    | 3     |
 | Codesys Go            | YES            |                   |           |                       |         |                           |               | YES                | 2     |
 | Siemens TIA           |                | ?                 |           | YES                   |         |                           |               |                    | 1     |
 | Codesys               | ?              |                   |           |                       |         |                           |               | YES                | 1     |
@@ -18,7 +19,6 @@ sort: score, alphabetical
 | Siemens S7            |                |                   |           |                       |         |                           |               |                    | 0     |
 | Siemens PCS7          |                |                   |           |                       |         |                           |               |                    | 0     |
 | Siemens PCS7 NEO      |                |                   |           |                       |         |                           |               |                    | 0     |
-| B&R Automation Studio | YES           |  YES           |           |  YES               |         |                           |  YES       |                    | 4     |
 | B&R Aprol             |                |                   |           |                       |         |                           |               |                    | 0     |
 | ...                   |                |                   |           |                       |         |                           |               |                    | 0     |
 


### PR DESCRIPTION
B&R Automation Studio checks a few more boxes than are currently marked.
Beckhoff has open docs, so that has been updated as well.

Here are some sources:

## Plaintext
I'm not sure where the docs explicitly say this, but I can share from experience that C and ST files are all stored as pure plaintext. VAR and TYP files are also plaintext and easy to edit outside of Automation Studio.

For reference, here is a Loupe open-source library for AS with plaintext code:
https://github.com/loupeteam/Piper/blob/main/src/Ar/Piper/Piper_PackML.c

## Testing framework
While I haven't used this framework much, it does exist.
https://help.br-automation.com/#/en/4/technologysolutions%2Fts_unittest%2Fgeneral%2Fts_unittest.html

## Open Download
Downloading and using AS simply requires an account.
https://www.br-automation.com/en-us/downloads/software/automation-studio/automation-studio-412/automation-studio-v412/

## Open docs
Until recently, the docs had to be downloaded. They are now available online like InfoSys.
https://help.br-automation.com/

Note: I also added a yes for Beckhoff in this category as InfoSys is freely available online
https://infosys.beckhoff.com/index_en.htm