### PR TITLE
Update Beckhoff information

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ sort: score, alphabetical
 
 | system                | plain text [1] | open download [2] | Linux [3] | testing framework [4] | cli [5] | transparent licensing [6] | open docs [7] | HW independent [8] | score |
 | --------------------- | -------------- | ----------------- | --------- | --------------------- | ------- | ------------------------- | ------------- | ------------------ | ----- |
+| Beckhoff TwinCAT 3    |                | YES               |           | YES                   |         |                           | YES           | YES                | 4     |
 | Siemens AX            | YES            |                   |           | YES                   | YES     |                           |               |                    | 3     |
-| Beckhoff TwinCAT 3    |                | YES               |           | YES                   |         |                           |               |                    | 2     |
 | Codesys Go            | YES            |                   |           |                       |         |                           |               | YES                | 2     |
 | Siemens TIA           |                | ?                 |           | YES                   |         |                           |               |                    | 1     |
 | Codesys               | ?              |                   |           |                       |         |                           |               | YES                | 1     |


### PR DESCRIPTION
Added "YES" under open docs and HW independent for Beckhoff.

Open docs:  a huge portion of documents for Beckhoff software and hardware are available for free with no login via the Infosys (infosys.bechhoff.com).  The search is horrendous and the general layout is bad but it's there!

HW independent:  TwinCAT can run on almost any computer that can run Windows and also BSD (and even more through virtualization).  The licensing is expensive on non-Beckhoff hardware but it can do it.  I have personally done this in a production environment with no issues.