### PR TITLE
feat: add some packages and infos to twincat chapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ Other notes:
 
 For automatic deployment and configuration of target platforms, Beckhoff's Windows based platforms support a variety of command line actions for configuration, some of which are demoed at https://github.com/Beckhoff-USA-Community/AutoDeployPCviaScript-main. In TwinCAT 4026, there will also be a chocolatey based package server. For BSD, Beckhoff provides a [package server](https://infosys.beckhoff.com/english.php?content=../content/1033/twincat_bsd/7669840651.html&id=3358471846380427993).
 
+There are third party CI/CD tools available as products for the TwinCAT ecosystem, for example CLI-Tools for configure, make and install and also tools for documentation generation and unit testing or enhancing code quality.
+- Zeugwerk Operations [build & test](https://github.com/Zeugwerk/zkbuild-action), [documentation generation](https://github.com/Zeugwerk/zkdoc-action)
+- [STweep](https://www.stweep.com/)
+
 #### Static Analysis, Unit Testing and Simulation
 
 Beckhoff provides [Static Analysis](https://www.beckhoff.com/en-us/products/automation/twincat/texxxx-twincat-3-engineering/te1200.html) which can perform basic checks for free or more extensive checks of the application for a fee. Static Analysis in TwinCAT 3 is relatively new and user experience may vary. The requirement to have a license on the development system also makes integration into a CI/CD pipeline difficult since it may not be easy or even possible to attach a USB device to a VM and may not be desireable to permanently assign a license to a ephemeral build environment.
@@ -101,6 +105,14 @@ Beckhoff does not officially support any Unit Testing methods, however extensive
 
 Beckhoff provides a variety of simulation tools, from simple methods including running the PLC locally on the developer's system without hardware to more extensive simulation of EtherCAT devices or via Simulink and other integrations.
 
+#### Library package manager
+
+There is [Twinpack](https://github.com/Zeugwerk/Twinpack) available as Open-Source library package manager. It provides an integrated User-Interface in TcXaeShell and also a command line tool to be able to use it easily in CI/CD systems like Jenkins.
+
+#### Frameworks
+
+With the above tools it is possible to use Frameworks like in IT-space also for Beckhoff TwinCAT on OT side. 
+- [Zeugwerk-Framework](https://zeugwerk.dev): Full Application framework with a bunch of libraries and an application template
 
 ### Codesys
 ...


### PR DESCRIPTION
just wanted to add some information to the Beckhoff TwinCAT part. Beckhoff itself does not have anything in the ci/cd space but there are companies who made stuff for Twincat. Also a library package manager is available with an cli.